### PR TITLE
Remove REQUIREMENTS.md check from the script, rely on the model

### DIFF
--- a/scripts/ralph-wiggum-bdd.sh
+++ b/scripts/ralph-wiggum-bdd.sh
@@ -276,11 +276,6 @@ if [[ "${INTERACTIVE_MODE}" == "false" ]] && [[ -z "${MAX_ITERATIONS}" ]]; then
     usage
 fi
 
-if [[ ! -f "REQUIREMENTS.md" ]]; then
-    echo "Error: REQUIREMENTS.md not found in current directory"
-    exit 1
-fi
-
 if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
     MAX_ITERATIONS=1
     PROMPT_FILE="/tmp/ralph-wiggum-bdd-prompt-$$.txt"


### PR DESCRIPTION
Remove REQUIREMENTS.md check from the script. This, together with a custom `--prompt` allows storing requirements in other places, like `specs/*.md`.