### PR TITLE
Allow docker socket (all sockets) in claude

### DIFF
--- a/examples/js/example1/.claude/settings.json
+++ b/examples/js/example1/.claude/settings.json
@@ -23,13 +23,13 @@
       "Bash(find *)",
       "Bash(grep *)",
       "Bash(ls *)",
-      "Bash(npm *)",
       "Bash(sort *)",
       "Bash(wc *)"
     ],
     "ask": [],
     "defaultMode": "default",
     "deny": [
+      "Bash(npm *)",
       "Bash(git config *)",
       "Bash(git push *)",
       "Bash(sudo *)",
@@ -41,7 +41,6 @@
       "Read(~/.aws/**)",
       "Read(~/.azure/**)",
       "Read(~/.config/gcloud/**)",
-      "Read(~/.gitconfig)",
       "Read(~/.ssh/**)",
       "Read(~/.terraform.d/**)",
       "Write(./.claude/settings.json)",
@@ -53,6 +52,7 @@
     "autoAllowBashIfSandboxed": true,
     "enabled": true,
     "network": {
+      "allowAllUnixSockets": true,
       "allowLocalBinding": true
     }
   }

--- a/examples/python/example1/.claude/settings.json
+++ b/examples/python/example1/.claude/settings.json
@@ -41,7 +41,6 @@
       "Read(~/.aws/**)",
       "Read(~/.azure/**)",
       "Read(~/.config/gcloud/**)",
-      "Read(~/.gitconfig)",
       "Read(~/.ssh/**)",
       "Read(~/.terraform.d/**)",
       "Write(./.claude/settings.json)",


### PR DESCRIPTION
Despite https://github.com/anthropic-experimental/sandbox-runtime/blob/7a4172b08ddc9963dbf35358815ca4938efcdd61/README.md?plain=1#L348 mentioning `enableWeakerNestedSandbox` - Enable weaker sandbox mode for Docker environments (boolean, default: false) this appears to be insufficient in `2.1.118 (Claude Code)`, so `allowAllUnixSockets` is set to true instead.